### PR TITLE
add changes to leaderboard

### DIFF
--- a/frontend/src/components/Home/Leaderboard.tsx
+++ b/frontend/src/components/Home/Leaderboard.tsx
@@ -30,7 +30,7 @@ const Leaderboard: React.FC = () => {
 
         const data = await response.json();
         const sorted = data.sort((a: any, b: any) => b.points - a.points);
-        setSortedColleges(sorted);
+        setSortedColleges(() => sorted);
       } catch (error) {
         console.error("Failed to fetch leaderboard:", error);
       } finally {
@@ -91,9 +91,8 @@ const Leaderboard: React.FC = () => {
               className={`flex flex-col items-center ${offset}text-center mb-3 cursor-pointer`}
             >
               <div
-                className={`relative ${
-                  size === "large" ? "w-52 h-52" : "w-24 h-24"
-                } flex items-center justify-center mb-4`}
+                className={`relative ${size === "large" ? "w-52 h-52" : "w-24 h-24"
+                  } flex items-center justify-center mb-4`}
               >
                 {/* Main College Flag */}
                 <Image
@@ -114,9 +113,8 @@ const Leaderboard: React.FC = () => {
                   width={size === "large" ? 400 : 50}
                   height={size === "large" ? 400 : 50}
                   layout="fixed"
-                  className={`absolute ${
-                    place === "first" ? "top-10" : "top-20"
-                  }`}
+                  className={`absolute ${place === "first" ? "top-10" : "top-20"
+                    }`}
                 />
               </div>
 
@@ -190,7 +188,7 @@ const Leaderboard: React.FC = () => {
                   </div>
                 </td>
                 <td className="w-[75px] text-sm text-center border border-gray-300 dark:border-gray-600">
-                  -0
+                  {college.dayChange}
                 </td>
                 <td className="w-[150px] px-6 py-4 text-sm border border-gray-300 dark:border-gray-600">
                   {college.points} points

--- a/frontend/src/components/Home/LeaderboardMobile.tsx
+++ b/frontend/src/components/Home/LeaderboardMobile.tsx
@@ -93,9 +93,8 @@ const Leaderboard: React.FC = () => {
               className={`flex flex-col items-center ${offset}text-center mb-3 cursor-pointer`}
             >
               <div
-                className={`relative ${
-                  size === "large" ? "w-52 h-52" : "w-24 h-24"
-                } flex items-center justify-center mb-4`}
+                className={`relative ${size === "large" ? "w-52 h-52" : "w-24 h-24"
+                  } flex items-center justify-center mb-4`}
               >
                 {/* Main College Flag */}
                 <Image
@@ -116,9 +115,8 @@ const Leaderboard: React.FC = () => {
                   width={size === "large" ? 400 : 50}
                   height={size === "large" ? 400 : 50}
                   layout="fixed"
-                  className={`absolute ${
-                    place === "first" ? "top-10" : "top-20"
-                  }`}
+                  className={`absolute ${place === "first" ? "top-10" : "top-20"
+                    }`}
                 />
               </div>
 


### PR DESCRIPTION
There's now a variable dayChange (updated everytime a match is scored) that can be used to conditionally display the changes of a college on a particular day. If the dayChange is 0 then there hasn't been any rank changes to the college during the day, if negative college rank went down if positive college rank went up, it's a bit hard to test this functionality so it might be a bit buggy but I checked all the cases I could think of. One might be that if the scores aren't added the same day the game is played. Maybe we could require that a game be scored ASAP to keep our leaderboard current 