### PR TITLE
fixed zero coins pendingBets loading bug

### DIFF
--- a/frontend/src/app/odds/page.tsx
+++ b/frontend/src/app/odds/page.tsx
@@ -134,7 +134,7 @@ const YoddsPage: React.FC = () => {
     };
 
     fetchPendingBets();
-  }, [availablePoints]);
+  }, [userEmail]);
 
   useEffect(() => {
     if (!pendingBets.length) return;


### PR DESCRIPTION
When ycoins were at zero for a user, the pending bets wouldn't load. This is fixed now - the pendingBets load when the userEmail is determined.