### PR TITLE
limit results on profile page

### DIFF
--- a/database/functions/src/getCollegeMatches.ts
+++ b/database/functions/src/getCollegeMatches.ts
@@ -10,7 +10,7 @@ const db = admin.firestore();
 export const getCollegeMatches = functions.https.onRequest(async (req, res) => {
   return corsHandler(req, res, async () => {
     try {
-      const { type, sortOrder = "desc", college } = req.query; // Retrieve 'type', 'sortOrder', and 'college' query parameters
+      const { type, sortOrder = "desc", college, limit = -1 } = req.query; // Retrieve 'type', 'sortOrder', and 'college' query parameters
       const currentDate = new Date();
       let query: Query = db.collection("matches"); // Explicitly use Query type
 
@@ -28,10 +28,17 @@ export const getCollegeMatches = functions.https.onRequest(async (req, res) => {
       const homeMatchesQuery = baseQuery.where("home_college", "==", college);
       const awayMatchesQuery = baseQuery.where("away_college", "==", college);
 
+      // Apply limit if specified
+      const queryLimit = Number(limit);
+      const limitedHomeMatchesQuery =
+        queryLimit > 0 ? homeMatchesQuery.limit(queryLimit) : homeMatchesQuery;
+      const limitedAwayMatchesQuery =
+        queryLimit > 0 ? awayMatchesQuery.limit(queryLimit) : awayMatchesQuery;
+
       // Execute both queries
       const [homeMatchesSnapshot, awayMatchesSnapshot] = await Promise.all([
-        homeMatchesQuery.get(),
-        awayMatchesQuery.get(),
+        limitedHomeMatchesQuery.get(),
+        limitedAwayMatchesQuery.get(),
       ]);
 
       // Combine the results from both queries

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -8,6 +8,7 @@ import { Match, Participant } from "@src/types/components";
 import LoadingScreen from "@src/components/LoadingScreen";
 import ListView from "@src/components/Profile/ListView";
 import { MdModeEditOutline } from "react-icons/md";
+import Link from "next/link";
 
 const Profile = () => {
   const { user, loading, signOut, setUser } = useUser();
@@ -21,6 +22,7 @@ const Profile = () => {
   const [correctPrediction, setCorrectPredictions] = useState(0);
 
   const userEmail = user ? user.email : null;
+  const matchesLimit = 3; // will fetch double this amount of matches; this number can be changed if wanted
 
   const cloudFunctionUrl = "https://getcollegematches-65477nrg6a-uc.a.run.app";
 
@@ -34,7 +36,7 @@ const Profile = () => {
           toCollegeAbbreviation[user.college] || user.college;
 
         const response = await fetch(
-          `${cloudFunctionUrl}?college=${userCollegeAbbreviation}&type=future&sortOrder=asc`,
+          `${cloudFunctionUrl}?college=${userCollegeAbbreviation}&type=future&sortOrder=asc&limit=${matchesLimit}`,
           {
             method: "GET",
             headers: {
@@ -257,6 +259,14 @@ const Profile = () => {
               {availableMatches.length > 0 ? (
                 <div className="w-full">
                   <ListView matches={availableMatches} isSignedUp={false} />
+                  <div className="flex justify-center w pt-4">
+                    <Link
+                      href="/schedules"
+                      className="p-2 sm:p-4 text-white text-xs sm:text-sm rounded-lg shadow transition duration-200 ease-in-out bg-blue-600 hover:scale-110"
+                    >
+                      See More on the Schedules Page!
+                    </Link>
+                  </div>
                 </div>
               ) : (
                 <div className="text-center mt-8 text-gray-600">


### PR DESCRIPTION
currently limited to 6 results, but this can easily be changed! also added a link to the schedules page (could be cool if it auto filtered to their college when clicked)

also when working on this i realized it might be good to add a ticket which refreshes the profile page when the user either signs up or unsigns up to a match, because right now when the user does that it doesn't update the lists unless they manually reload