### PR TITLE
Score undo match v2 functions

### DIFF
--- a/database/functions/src/addSchedule.ts
+++ b/database/functions/src/addSchedule.ts
@@ -24,7 +24,7 @@ const canAddSchedule = (role: string) => {
 export const addSchedule = functions.https.onRequest(async (req, res) => {
   corsHandler(req, res, async () => {
     if (req.method !== "POST") {
-      return res.status(405).send("Method Not Allowed");
+      return res.status(405).json({ error: "Method Not Allowed" });
     }
 
     const authHeader = req.headers.authorization || "";

--- a/database/functions/src/undoScoreMatch.ts
+++ b/database/functions/src/undoScoreMatch.ts
@@ -46,7 +46,7 @@ const getPointsForWinBySportName = async (
 export const undoScoreMatch = functions.https.onRequest(async (req, res) => {
   return corsHandler(req, res, async () => {
     if (req.method !== "POST") {
-      return res.status(405).send("Method Not Allowed");
+      return res.status(405).json({ error: "Method Not Allowed" });
     }
 
     const authHeader = req.headers.authorization || "";

--- a/frontend/src/app/api/functions/scoreMatch/route.ts
+++ b/frontend/src/app/api/functions/scoreMatch/route.ts
@@ -1,0 +1,50 @@
+import { cookies } from "next/headers";
+
+export async function POST(req: Request) {
+  const {
+    matchId,
+    homeScore,
+    awayScore,
+    homeForfeit,
+    awayForfeit,
+    homeTeam,
+    awayTeam,
+    sport,
+    year,
+  } = await req.json();
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get("token");
+
+  if (!token) {
+    return new Response(JSON.stringify({ error: "unauthenticated" }), {
+      status: 401,
+    });
+  }
+
+  const response = await fetch("https://scorematch-65477nrg6a-uc.a.run.app", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token.value}`,
+    },
+    body: JSON.stringify({
+      matchId,
+      homeScore,
+      awayScore,
+      homeForfeit,
+      awayForfeit,
+      homeTeam,
+      awayTeam,
+      sport,
+      year,
+    }),
+  });
+
+  if (!response.ok) {
+    return new Response(await response.text(), { status: response.status });
+  }
+
+  const data = await response.json();
+  return Response.json(data);
+}

--- a/frontend/src/app/api/functions/undoScoreMatch/route.ts
+++ b/frontend/src/app/api/functions/undoScoreMatch/route.ts
@@ -1,0 +1,36 @@
+import { cookies } from "next/headers";
+
+export async function POST(req: Request) {
+  const { matchId, year } = await req.json();
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get("token");
+
+  if (!token) {
+    return new Response(JSON.stringify({ error: "unauthenticated" }), {
+      status: 401,
+    });
+  }
+
+  const response = await fetch(
+    "https://undoscorematch-65477nrg6a-uc.a.run.app",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token.value}`,
+      },
+      body: JSON.stringify({
+        matchId,
+        year,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    return new Response(await response.text(), { status: response.status });
+  }
+
+  const data = await response.json();
+  return Response.json(data);
+}

--- a/frontend/src/app/hub/add-scores/page.tsx
+++ b/frontend/src/app/hub/add-scores/page.tsx
@@ -6,6 +6,7 @@ import MatchCard from "@src/components/AddScores/MatchCard";
 import LoadingScreen from "@src/components/LoadingScreen";
 import { useSeason } from "@src/context/SeasonContext";
 import withRoleProtectedRoute from "@src/components/withRoleProtectedRoute";
+import { currentYear } from "@src/utils/helpers";
 
 const AddScoresPage: React.FC = () => {
   const [matches, setMatches] = useState<Match[]>([]);
@@ -14,6 +15,7 @@ const AddScoresPage: React.FC = () => {
   const [unscoreMessage, setUnscoreMessage] = useState<string | null>(null);
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false); // For confirmation modal
   const { currentSeason } = useSeason();
+  const year = currentSeason?.year || currentYear;
 
   useEffect(() => {
     document.title = "Score Matches";
@@ -24,9 +26,7 @@ const AddScoresPage: React.FC = () => {
       setLoading(true);
       try {
         const response = await fetch(
-          `/api/functions/getUnscoredMatches?seasonId=${
-            currentSeason?.year || "2025-2026"
-          }`
+          `/api/functions/getUnscoredMatches?seasonId=${year}`
         );
 
         if (response.ok) {
@@ -49,17 +49,14 @@ const AddScoresPage: React.FC = () => {
 
     try {
       const userToken = sessionStorage.getItem("userToken");
-      const response = await fetch(
-        "https://us-central1-yims-125a2.cloudfunctions.net/undoScoreMatch",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${userToken}`,
-          },
-          body: JSON.stringify({ matchId: unscoreId }),
-        }
-      );
+      const response = await fetch("/api/functions/undoScoreMatch", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${userToken}`,
+        },
+        body: JSON.stringify({ matchId: unscoreId, year }),
+      });
 
       if (response.ok) {
         setUnscoreMessage("Successfully unscored the match.");


### PR DESCRIPTION
These functions are updated to work with the new year system and go through an api route. They also check for the user role to ensure they are allowed to make the changes. I did not fully test with bets as there is still an open item there, but for all else it works. The college ranks get appropriately updated when points are added but something seems to be weird with the rank change arrows, but i'm thinking this just may be weird because they all have previous rank = 0 and will be normal once real scores start to be added.

Open items/questions: 
- we need to ensure that we are updating points with the right logic; this has to be verified with IMs people
- see the comment in the scoreMatch function in the settleParlayLegs function. That is the only part not yet updated to account for year but I put a possible solution in the comment.